### PR TITLE
Make tests parallel-safe

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,6 +23,10 @@ my %WriteMakefileArgs = (
 	'Scalar::Util' => 0,
 	'Unicode::UTF8' => '0.62',
     },
+    TEST_REQUIRES => {
+	'File::Spec' => '0',
+	'File::Temp' => '0',
+    },
     META_MERGE => {
 	'meta-spec' => {
 	    version => 2,

--- a/t/write-json.t
+++ b/t/write-json.t
@@ -2,6 +2,8 @@ use warnings;
 use strict;
 use utf8;
 use FindBin '$Bin';
+use File::Spec;
+use File::Temp;
 use Test::More;
 my $builder = Test::More->builder;
 binmode $builder->output,         ":utf8";
@@ -11,17 +13,12 @@ binmode STDOUT, ":encoding(utf8)";
 binmode STDERR, ":encoding(utf8)";
 use JSON::Create 'write_json';
 use JSON::Parse 'json_file_to_perl';
-my $out = "$Bin/test-write-json.json";
-if (-f $out) {
-    unlink $out or warn "Failed to unlink $out: $!";
-}
+my $directory = File::Temp->newdir;
+my $out = File::Spec->catfile($directory, "test-write-json.json");
 # It's your thing.
 my $thing = {a => 'b', c => 'd'};
 write_json ($out, $thing);
 ok (-f $out, "Wrote a file");
 my $roundtrip = json_file_to_perl ($out);
 is_deeply ($roundtrip, $thing);
-if (-f $out) {
-    unlink $out or warn "Failed to unlink $out: $!";
-}
 done_testing ();


### PR DESCRIPTION
t/write-json.t writes into a temporary file. t/zz-pure-perl.t executes
t/write-json.t. If tests are run in parallel, t/write-json.t can run
twice an trip over the same file.

This patch fixes it by creating a temporary directory whose name
unique. File::Temp also removes the directory automatically.